### PR TITLE
FIX older documents did not apear in search

### DIFF
--- a/controllers/repair.js
+++ b/controllers/repair.js
@@ -78,6 +78,8 @@ module.exports.searchRepairs = async (req, res) => {
     //generate aggregate must array
     const aggregateArr = getAggregate(searchStr);
 
+    //!
+    console.log(aggregateArr);
     //individual text search aggregate from given phrase
     const results = await Repair.aggregate([
       {
@@ -89,7 +91,7 @@ module.exports.searchRepairs = async (req, res) => {
         },
       },
       {
-        $match: { removed: false },
+        $match: { removed: { $ne: true } },
       },
     ]);
 

--- a/modules/getAggregate.js
+++ b/modules/getAggregate.js
@@ -12,7 +12,7 @@ function getAggregate(str) {
 //make querys for aggregate query
 function makeQuerys(str) {
   if (str === "" || str === undefined) return [];
-  //get all words and remove spaces save into array
+  //get all words and remove spaces and save into array
   const wordsArr = str.split(" ").filter((word) => {
     const noSpace = word.trim();
     if (noSpace !== "") {
@@ -27,7 +27,7 @@ function makeQuerys(str) {
       text: {
         query: word,
         path: { wildcard: "*" },
-        fuzzy: { maxEdits: 2.0 },
+        fuzzy: { maxEdits: 1.0 },
       },
     };
   });


### PR DESCRIPTION
tested older document titles and verified they are returned by the search. 
test documents that have been removed do not show up in search results as expected.

used $match: { removed: { $ne: true } }, operator now as long as a removed field does not equal true, the filter will allow the document to show up in search.