### PR TITLE
Add way to delete images on front end on new repair form

### DIFF
--- a/backend/controllers/images.js
+++ b/backend/controllers/images.js
@@ -1,0 +1,7 @@
+const router = require("express").Router();
+
+module.exports = {
+  deleteImage: async (request, response) => {
+    res.send({ route: "images delete" });
+  },
+};

--- a/backend/routes/api/images.js
+++ b/backend/routes/api/images.js
@@ -1,0 +1,6 @@
+const router = require("express").Router();
+const imagesController = require("../../controllers/images.js");
+
+router.delete("/", imagesController.deleteImage);
+
+module.exports = router;

--- a/backend/routes/api/index.js
+++ b/backend/routes/api/index.js
@@ -3,6 +3,7 @@ const apiAuthController = require("../../controllers/api/apiAuth");
 const { ensureAuthApi } = require("../../middleware/auth");
 const repairRouter = require("./repairs");
 const signatureRouter = require("./signature.js");
+const imagesRouter = require("./images.js");
 
 router.post("/login", apiAuthController.apiLogin);
 router.get("/logout", apiAuthController.apiLogout);
@@ -10,5 +11,6 @@ router.post("/signup", apiAuthController.apiSignup);
 
 router.use("/repairs", ensureAuthApi, repairRouter);
 router.use("/signform", ensureAuthApi, signatureRouter);
+router.use("/images", ensureAuthApi, imagesRouter);
 
 module.exports = router;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -18,6 +18,7 @@
         "autoprefixer": "^10.4.17",
         "axios": "^1.6.7",
         "daisyui": "^4.7.0",
+        "lucide-react": "^0.358.0",
         "postcss": "^8.4.35",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -3204,6 +3205,14 @@
       "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
       "engines": {
         "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.358.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.358.0.tgz",
+      "integrity": "sha512-rBSptRjZTMBm24zsFhR6pK/NgbT18JegZGKcH4+1H3+UigMSRpeoWLtR/fAwMYwYnlJOZB+y8WpeHne9D6X6Kg==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/memoize-one": {

--- a/client/package.json
+++ b/client/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.4.17",
     "axios": "^1.6.7",
     "daisyui": "^4.7.0",
+    "lucide-react": "^0.358.0",
     "postcss": "^8.4.35",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/api/RepairReportsApi.ts
+++ b/client/src/api/RepairReportsApi.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { Repair } from "../classes/Repair";
+import { signatureT } from "../../types";
 const API_URL = import.meta.env.VITE_API_URL;
 
 const getLatestRepairs = async (limit: string | number) => {

--- a/client/src/classes/ImageObj.ts
+++ b/client/src/classes/ImageObj.ts
@@ -1,4 +1,5 @@
 import { ImageObjT } from "../../types";
+import { v4 as uuidv4 } from "uuid";
 
 export class ImageObj implements ImageObjT {
   public imageUrl = "";
@@ -6,5 +7,7 @@ export class ImageObj implements ImageObjT {
   public caption = "";
   public imageId = "";
   public folder = "testFolder";
-  constructor() {}
+  constructor() {
+    this.imageId = uuidv4();
+  }
 }

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -142,10 +142,10 @@ export function EditImageCard({
       const tempImageObj = { ...imageUploadedObj };
       try {
         console.log("deleteImage called", deleteImage);
-        // deleteImage(imageUploadedObj?.imageId);
-        throw "test image fail";
+        deleteImage(imageUploadedObj.imageId);
         setImageUploadedObj(null);
       } catch (error) {
+        // reset image obj and do not remove from dom
         alert("failed to delete image");
         setImageUploadedObj(tempImageObj);
         return;

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -4,7 +4,7 @@ import { CameraPreview } from "./CameraPreview";
 import { ImageObjT } from "../../../types";
 import { useDebouncedCallback } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
-import useImageManager from "../../hooks/useImageManager";
+import useImageDb from "../../hooks/useImageManager";
 import { Check } from "lucide-react";
 
 enum UploadStatus {
@@ -17,12 +17,14 @@ enum UploadStatus {
 export function EditImageCard({
   url = "",
   setFormImageUrl,
+  onRemove,
 }: {
   url: string;
+  onRemove: () => void;
   setFormImageUrl: (imageObj: ImageObjT) => void; //external state setter to manipulate url prop
 }) {
   // const uploadImage = useUploadImage();
-  const { deleteImage, uploadImage } = useImageManager();
+  const { uploadImage } = useImageDb();
   //ref used to interact with node that is rendered to dom and get its current properties
   //will hold <video> tag reference
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -51,9 +53,10 @@ export function EditImageCard({
 
   //is camera active
   const [activeCamera, setActiveCamera] = useState(false);
+
+  //has image been uploaded
   const [isUploaded, setIsUploaded] = useState(false);
 
-  //todo handle upload status for user
   const [imageUploadStatus, setImageUploadStatus] = useState<UploadStatus>(
     UploadStatus.SUCCESS
   );
@@ -71,6 +74,7 @@ export function EditImageCard({
       }
 
       setIsUploaded(false);
+
       setFormImageUrl({
         folder: "testFolder",
         imageId: urlText,
@@ -122,10 +126,14 @@ export function EditImageCard({
     alert("no image to upload");
   }, 1000);
 
-  const handleImageDelete = useDebouncedCallback(async (url: string) => {
-    deleteImage(url);
+  const handleImageDelete = async () => {
+    // deleteImage(url);
+    //delete image if uploaded
+    //delete self from list
+
     setIsUploaded(false);
-  }, 1000);
+    onRemove();
+  };
 
   const handleFileChange = async (
     event: React.ChangeEvent<HTMLInputElement>
@@ -226,7 +234,10 @@ export function EditImageCard({
     <div
       key={uuidv4()}
       className="">
-      <div className="btn btn-circle bg-yellow-600 absolute right-0 hover:bg-red-600 hover:scale-125">
+      {/* delete x button */}
+      <div
+        onClick={handleImageDelete}
+        className="btn btn-circle bg-yellow-600 absolute right-0 hover:bg-red-600 hover:scale-125">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"
@@ -244,6 +255,7 @@ export function EditImageCard({
 
       {/* alerts and status */}
       <section className=" flex flex-col items-center h-1/8">
+        {/* upload progress bar */}
         {imageUploadStatus == UploadStatus.UPLOADING && (
           <div className="">
             <span className="loading loading-spinner text-accent"></span>
@@ -253,28 +265,15 @@ export function EditImageCard({
               max="100"></progress>
           </div>
         )}
+
+        {/* uploaded success badge */}
         {imageUploadStatus == UploadStatus.SUCCESS && (
           <div className="badge bg-green-500 text-black absolute left-0">
             <Check className=" text-slate-800" /> uploaded
           </div>
-          // <div
-          //   role="alert"
-          //   className="alert alert-success">
-          //   <svg
-          //     xmlns="http://www.w3.org/2000/svg"
-          //     className="stroke-current shrink-0 h-6 w-6"
-          //     fill="none"
-          //     viewBox="0 0 24 24">
-          //     <path
-          //       strokeLinecap="round"
-          //       strokeLinejoin="round"
-          //       strokeWidth="2"
-          //       d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-          //     />
-          //   </svg>
-          //   <span>Your Image was uploaded!</span>
-          // </div>
         )}
+
+        {/* error alert strip */}
         {imageUploadStatus == UploadStatus.ERROR && (
           <div
             role="alert"

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -1,9 +1,10 @@
 import React, { useState, useRef, useEffect } from "react";
-import useUploadImage from "../../hooks/useUploadImage";
+// import useUploadImage from "../../hooks/useUploadImage";
 import { CameraPreview } from "./CameraPreview";
 import { ImageObjT } from "../../../types";
 import { useDebouncedCallback } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
+import useImageManager from "../../hooks/useImageManager";
 
 enum UploadStatus {
   SUCCESS,
@@ -19,8 +20,8 @@ export function EditImageCard({
   url: string;
   setFormImageUrl: (imageObj: ImageObjT) => void; //external state setter to manipulate url prop
 }) {
-  const uploadImage = useUploadImage();
-
+  // const uploadImage = useUploadImage();
+  const { deleteImage, uploadImage } = useImageManager();
   //ref used to interact with node that is rendered to dom and get its current properties
   //will hold <video> tag reference
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -115,6 +116,10 @@ export function EditImageCard({
     }
 
     alert("no image to upload");
+  }, 1000);
+
+  const handleImageDelete = useDebouncedCallback(async (url: string) => {
+    deleteImage(url);
   }, 1000);
 
   const handleFileChange = async (
@@ -214,6 +219,21 @@ export function EditImageCard({
     <div
       key={uuidv4()}
       className="">
+      <div className="btn btn-circle  bg-yellow-600 absolute right-0 hover:bg-red-600 hover:scale-125">
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          className="h-6 w-6"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="black">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            d="M6 18L18 6M6 6l12 12"
+          />
+        </svg>
+      </div>
       {/* alerts and status */}
       <section className=" flex flex-col items-center h-1/8">
         {imageUploadStatus == UploadStatus.UPLOADING && (

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -5,6 +5,7 @@ import { ImageObjT } from "../../../types";
 import { useDebouncedCallback } from "use-debounce";
 import { v4 as uuidv4 } from "uuid";
 import useImageManager from "../../hooks/useImageManager";
+import { Check } from "lucide-react";
 
 enum UploadStatus {
   SUCCESS,
@@ -50,10 +51,11 @@ export function EditImageCard({
 
   //is camera active
   const [activeCamera, setActiveCamera] = useState(false);
+  const [isUploaded, setIsUploaded] = useState(false);
 
   //todo handle upload status for user
   const [imageUploadStatus, setImageUploadStatus] = useState<UploadStatus>(
-    UploadStatus.IDLE
+    UploadStatus.SUCCESS
   );
 
   const [uploadProgress, setUploadProgress] = useState(10);
@@ -68,6 +70,7 @@ export function EditImageCard({
         return;
       }
 
+      setIsUploaded(false);
       setFormImageUrl({
         folder: "testFolder",
         imageId: urlText,
@@ -106,6 +109,7 @@ export function EditImageCard({
         setFormImageUrl(imageObj);
         setUploadProgress(100);
         setImageUploadStatus(UploadStatus.SUCCESS);
+        setIsUploaded(true);
         return;
       } catch (error) {
         console.log("error uploading", error);
@@ -120,6 +124,7 @@ export function EditImageCard({
 
   const handleImageDelete = useDebouncedCallback(async (url: string) => {
     deleteImage(url);
+    setIsUploaded(false);
   }, 1000);
 
   const handleFileChange = async (
@@ -143,6 +148,7 @@ export function EditImageCard({
 
         handleUrlChange(reader.result);
         // await handleImageUpload("testfolder");
+        setIsUploaded(false);
       };
 
       //read the file data and trigger onloadend event
@@ -212,6 +218,7 @@ export function EditImageCard({
       setImagePreview(dataUrl);
       setActiveCamera(false);
       handleUrlChange(dataUrl);
+      setIsUploaded(false);
     }
   };
 
@@ -219,7 +226,7 @@ export function EditImageCard({
     <div
       key={uuidv4()}
       className="">
-      <div className="btn btn-circle  bg-yellow-600 absolute right-0 hover:bg-red-600 hover:scale-125">
+      <div className="btn btn-circle bg-yellow-600 absolute right-0 hover:bg-red-600 hover:scale-125">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-6 w-6"
@@ -234,6 +241,7 @@ export function EditImageCard({
           />
         </svg>
       </div>
+
       {/* alerts and status */}
       <section className=" flex flex-col items-center h-1/8">
         {imageUploadStatus == UploadStatus.UPLOADING && (
@@ -246,23 +254,26 @@ export function EditImageCard({
           </div>
         )}
         {imageUploadStatus == UploadStatus.SUCCESS && (
-          <div
-            role="alert"
-            className="alert alert-success">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="stroke-current shrink-0 h-6 w-6"
-              fill="none"
-              viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <span>Your Image was uploaded!</span>
+          <div className="badge bg-green-500 text-black absolute left-0">
+            <Check className=" text-slate-800" /> uploaded
           </div>
+          // <div
+          //   role="alert"
+          //   className="alert alert-success">
+          //   <svg
+          //     xmlns="http://www.w3.org/2000/svg"
+          //     className="stroke-current shrink-0 h-6 w-6"
+          //     fill="none"
+          //     viewBox="0 0 24 24">
+          //     <path
+          //       strokeLinecap="round"
+          //       strokeLinejoin="round"
+          //       strokeWidth="2"
+          //       d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+          //     />
+          //   </svg>
+          //   <span>Your Image was uploaded!</span>
+          // </div>
         )}
         {imageUploadStatus == UploadStatus.ERROR && (
           <div
@@ -357,13 +368,15 @@ export function EditImageCard({
             {!activeCamera ? "open camera" : "close camera"}
           </div>
 
-          <div
-            onClick={() => {
-              handleImageUpload("testfolder");
-            }}
-            className="btn btn-sm">
-            Manual Upload Image
-          </div>
+          {!isUploaded && (
+            <div
+              onClick={() => {
+                handleImageUpload("testfolder");
+              }}
+              className="btn btn-sm">
+              Manual Upload Image
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -175,8 +175,9 @@ export function EditImageCard({
         setImagePreview(reader.result);
 
         handleUrlChange(reader.result);
-        // await handleImageUpload("testfolder");
-        setImageUploadedObj(false);
+
+        //reset state to not uploaded yet state
+        setImageUploadedObj(null);
       };
 
       //read the file data and trigger onloadend event

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -40,7 +40,7 @@ export function EditImageCard({
   );
 
   const [imageUploadStatus, setImageUploadStatus] = useState<UploadStatus>(
-    UploadStatus.SUCCESS
+    UploadStatus.IDLE
   );
 
   const [uploadProgress, setUploadProgress] = useState(10);
@@ -143,13 +143,14 @@ export function EditImageCard({
       try {
         console.log("deleteImage called", deleteImage);
         // deleteImage(imageUploadedObj?.imageId);
+        throw "test image fail";
         setImageUploadedObj(null);
       } catch (error) {
         alert("failed to delete image");
         setImageUploadedObj(tempImageObj);
+        return;
       }
     }
-
     onRemove();
   };
 

--- a/client/src/components/ImageCard/EditImageCard.tsx
+++ b/client/src/components/ImageCard/EditImageCard.tsx
@@ -141,8 +141,9 @@ export function EditImageCard({
     if (imageUploadedObj) {
       const tempImageObj = { ...imageUploadedObj };
       try {
-        console.log("deleteImage called", deleteImage);
-        deleteImage(imageUploadedObj.imageId);
+        // console.log("deleteImage called", deleteImage);
+        const deleteResponse = await deleteImage(imageUploadedObj.imageId);
+        console.log("deleteResponse", deleteResponse);
         setImageUploadedObj(null);
       } catch (error) {
         // reset image obj and do not remove from dom

--- a/client/src/components/ProcedureList/EditProcedureCard.tsx
+++ b/client/src/components/ProcedureList/EditProcedureCard.tsx
@@ -5,6 +5,7 @@ import { EditImageCard } from "../ImageCard/EditImageCard";
 import { v4 as uuidv4 } from "uuid";
 import { useDebouncedCallback } from "use-debounce";
 import { ImageObjT, ProcedureT } from "../../../types";
+import { ImageObj } from "../../classes/ImageObj";
 
 export default function EditProcedureCard({
   proc,
@@ -17,6 +18,7 @@ export default function EditProcedureCard({
     instructions: (text: string) => void;
     addImage: () => void;
     editImage: (imageIndex: number, updatedImageObj: ImageObjT) => void;
+    removeImage: (imageIndex: number) => void;
   };
 }) {
   //index to number to be used as reference of updating state array of the proceduresArray
@@ -25,11 +27,12 @@ export default function EditProcedureCard({
   // const { formDispatch } = useContext(RepairFormContext);
 
   const [instructions, setInstructions] = useState(proc.instructions);
-  const images = proc.images;
+  const { imageObjs } = proc;
 
   const imageCards = createEditImageCards({
-    imageUrls: images,
+    imageObjs: imageObjs,
     updateUrl: updateProcedure.editImage,
+    onRemove: updateProcedure.removeImage,
   });
 
   const handleInstructionsUpdate = useDebouncedCallback((text: string) => {
@@ -79,16 +82,23 @@ export default function EditProcedureCard({
 }
 
 function createEditImageCards({
-  imageUrls,
   updateUrl,
+  imageObjs,
+  onRemove,
 }: {
-  imageUrls: string[];
+  imageObjs: ImageObjT[];
   updateUrl: (imageIndex: number, newImageObj: ImageObjT) => void;
+  onRemove?: (imageIndex: number) => void;
 }) {
-  const imageCards = imageUrls.map((url, index) => {
+  const imageCards = imageObjs.map((imageObj, index) => {
+    const { imageUrl } = imageObj;
     // high order function to update url
     const updateImageUrl = ({ imageUrl, imageId, folder }: ImageObjT) => {
-      updateUrl(index, { imageUrl, imageId, folder });
+      updateUrl(index, { ...new ImageObj(), ...{ imageUrl, imageId, folder } });
+    };
+
+    const removeImageFromList = () => {
+      if (onRemove) onRemove(index);
     };
 
     return (
@@ -96,8 +106,9 @@ function createEditImageCards({
         className="w-full card md:w-1/3 bg-slate-700 p-2"
         key={uuidv4()}>
         <EditImageCard
+          onRemove={removeImageFromList}
           key={uuidv4()}
-          url={url}
+          url={imageUrl}
           setFormImageUrl={updateImageUrl}
         />
       </li>

--- a/client/src/components/ProcedureList/EditProcedureCard.tsx
+++ b/client/src/components/ProcedureList/EditProcedureCard.tsx
@@ -18,7 +18,7 @@ export default function EditProcedureCard({
     instructions: (text: string) => void;
     addImage: () => void;
     editImage: (imageIndex: number, updatedImageObj: ImageObjT) => void;
-    removeImage: (imageIndex: number) => void;
+    removeImage: (imageId: string) => void;
   };
 }) {
   //index to number to be used as reference of updating state array of the proceduresArray
@@ -88,17 +88,17 @@ function createEditImageCards({
 }: {
   imageObjs: ImageObjT[];
   updateUrl: (imageIndex: number, newImageObj: ImageObjT) => void;
-  onRemove?: (imageIndex: number) => void;
+  onRemove?: (imageId: string) => void;
 }) {
   const imageCards = imageObjs.map((imageObj, index) => {
-    const { imageUrl } = imageObj;
+    const { imageUrl, imageId } = imageObj;
     // high order function to update url
     const updateImageUrl = ({ imageUrl, imageId, folder }: ImageObjT) => {
       updateUrl(index, { ...new ImageObj(), ...{ imageUrl, imageId, folder } });
     };
 
     const removeImageFromList = () => {
-      if (onRemove) onRemove(index);
+      if (onRemove) onRemove(imageId);
     };
 
     return (

--- a/client/src/components/ProcedureList/EditProcedureList.tsx
+++ b/client/src/components/ProcedureList/EditProcedureList.tsx
@@ -48,10 +48,10 @@ export default function EditProcedureList({
     };
 
     //! working on this
-    const removeImage = (imageIndex: number) => {
+    const removeImage = (imageId: string) => {
       formDispatch({
         type: "REMOVE_IMAGE",
-        payload: { imageIndex, procIndex: procedureIndex },
+        payload: { imageId, procIndex: procedureIndex },
       });
     };
 

--- a/client/src/components/ProcedureList/EditProcedureList.tsx
+++ b/client/src/components/ProcedureList/EditProcedureList.tsx
@@ -22,46 +22,58 @@ export default function EditProcedureList({
     });
   };
 
-  const procedures = procedureList.map((proc, index) => {
+  const procedures = procedureList.map((procedureData, procedureIndex) => {
     const instructions = (text: string) => {
       formDispatch({
         type: "UPDATE_INTRUC",
-        payload: { procIndex: index, instructions: text },
+        payload: { procIndex: procedureIndex, instructions: text },
       });
     };
     const addImage = () => {
       formDispatch({
         type: "ADD_IMAGE",
-        payload: { procIndex: index },
+        payload: { procIndex: procedureIndex },
       });
     };
 
-    //! working here
     const editImage = (imageIndex: number, updatedImageObj: ImageObjT) => {
       formDispatch({
         type: "UPDATE_IMAGES",
         payload: {
-          procIndex: index,
-          newImageIndex: imageIndex,
+          procIndex: procedureIndex,
+          imageIndex: imageIndex,
           newImageObj: updatedImageObj,
         },
       });
     };
 
+    //! working on this
+    const removeImage = (imageIndex: number) => {
+      formDispatch({
+        type: "REMOVE_IMAGE",
+        payload: { imageIndex, procIndex: procedureIndex },
+      });
+    };
+
     //object with update functions for editProcedureCard component
-    const updateProcedure = { instructions, addImage, editImage };
+    const updateProcedureMethods = {
+      instructions,
+      addImage,
+      editImage,
+      removeImage,
+    };
 
     return (
       <li key={uuidv4()}>
         <EditProcedureCard
-          updateProcedure={updateProcedure}
-          proc={proc}
-          index={index}
+          updateProcedure={updateProcedureMethods}
+          proc={procedureData}
+          index={procedureIndex}
         />
 
         <div
           onClick={() => {
-            addNewProcedure(index + 1);
+            addNewProcedure(procedureIndex + 1);
           }}
           className="btn">
           Add new Procedure here

--- a/client/src/hooks/useImageManager.tsx
+++ b/client/src/hooks/useImageManager.tsx
@@ -5,11 +5,13 @@ import useRepairApi from "./useRepairApi";
 import { signatureT } from "../../types";
 import useAuthContext from "./useAuthContext";
 
-export default function useUploadImage() {
+const IMAGE_API_URL = import.meta.env.VITE_API_URL;
+
+export default function useImageManager() {
   const { getUploadSignature } = useRepairApi();
   const { unauthorizedError } = useAuthContext();
 
-  return async function uploadImage(imageFile: File | string, folder: string) {
+  async function uploadImage(imageFile: File | string, folder: string) {
     let signData;
     try {
       signData = await getUploadSignature(folder);
@@ -37,9 +39,27 @@ export default function useUploadImage() {
     const formData = await createForm({ imageFile, signData });
 
     //upload to cloudinary
-    const response = axios.post(url, formData);
+    const response = await axios.post(url, formData);
+    console.log("response", response);
     return response;
-  };
+  }
+
+  async function deleteImage(imageUrl: string) {
+    //   "public_id": "testfolder/voxv6ccg3pz15uqsyrfb",
+    // "url": "http://res.cloudinary.com/da6jwh1id/image/upload/v1710692119/testfolder/voxv6ccg3pz15uqsyrfb.png",
+
+    const url = `${IMAGE_API_URL}/images`;
+
+    //upload to cloudinary
+    const response = axios.delete(url, {
+      data: imageUrl,
+      withCredentials: true,
+    });
+
+    return response;
+  }
+
+  return { uploadImage, deleteImage };
 }
 
 // function getImages(element) {
@@ -87,3 +107,28 @@ async function createForm({
 
   return formData;
 }
+
+//image upload response
+// {
+//   "asset_id": "bb3498945289512b8d701676d3705cab",
+//   "public_id": "testfolder/voxv6ccg3pz15uqsyrfb",
+//   "version": 1710692119,
+//   "version_id": "fd7dbdc31fdec140e27a3bcb6f4b5372",
+//   "signature": "065bdfead0e493b97f2ceb92f2efec9c0d6eaec6",
+//   "width": 640,
+//   "height": 480,
+//   "format": "png",
+//   "resource_type": "image",
+//   "created_at": "2024-03-17T16:15:19Z",
+//   "tags": [],
+//   "bytes": 404617,
+//   "type": "upload",
+//   "etag": "6a9abfb0e592e780b16099df1a8f41cf",
+//   "placeholder": false,
+//   "url": "http://res.cloudinary.com/da6jwh1id/image/upload/v1710692119/testfolder/voxv6ccg3pz15uqsyrfb.png",
+//   "secure_url": "https://res.cloudinary.com/da6jwh1id/image/upload/v1710692119/testfolder/voxv6ccg3pz15uqsyrfb.png",
+//   "folder": "testfolder",
+//   "original_filename": "image",
+//   "original_extension": "jpg",
+//   "api_key": "492571145989964"
+// }

--- a/client/src/hooks/useRepairApi.ts
+++ b/client/src/hooks/useRepairApi.ts
@@ -1,16 +1,9 @@
 import axios, { AxiosError } from "axios";
 import { Repair } from "../classes/Repair";
 import useAuthContext from "./useAuthContext";
+import { signatureT } from "../../types";
 
 const API_URL = import.meta.env.VITE_API_URL;
-
-export type signatureT = {
-  apikey: string;
-  cloudname: string;
-  signature: string;
-  timestamp: number;
-  folder: string;
-};
 
 const useRepairApi = () => {
   const { unauthorizedError } = useAuthContext();

--- a/client/src/hooks/useRepairFormState.ts
+++ b/client/src/hooks/useRepairFormState.ts
@@ -1,40 +1,13 @@
 import { useReducer } from "react";
-import { ChangeFormPayloadT, RepairFormDispatchType } from "../../types";
+import {
+  ChangeFormPayloadT,
+  ImageObjT,
+  RepairFormStateActionT,
+} from "../../types";
 import { Repair } from "../classes/Repair";
 import { ImageObj } from "../classes/ImageObj";
 import { Procedure } from "../classes/Procedure";
 const LOC = "@useRepairFormState ";
-
-// class ImageObj implements ImageObjT {
-//   public imageUrl = "";
-//   public imageThumb = "";
-//   public caption = "";
-//   public imageId = "";
-//   public folder = "testFolder";
-//   constructor() {}
-// }
-
-// export class Procedure implements ProcedureT {
-//   public images = [];
-//   public imageObjs: ImageObjT[] = [];
-//   public imagesIdArr = [];
-//   public instructions = "";
-//   public procedureNum = 0;
-//   public thumbs = [];
-
-//   constructor() {}
-// }
-
-// export class Repair {
-//   public boardType = "other";
-//   public engineMake = "other";
-//   public group = "public";
-//   public procedureArr: ProcedureT[] = [new Procedure()];
-//   public title = "New Repair";
-//   public searchTags: string[] = [];
-
-//   constructor() {}
-// }
 
 export const newRepairForm = new Repair();
 
@@ -47,10 +20,7 @@ export default function useRepairFormState() {
   return { currentFormState, formDispatch };
 }
 
-function updateFormDataReducer(
-  state: Repair,
-  action: { type: RepairFormDispatchType; payload: ChangeFormPayloadT }
-) {
+function updateFormDataReducer(state: Repair, action: RepairFormStateActionT) {
   let newState = state;
   switch (action.type) {
     case "ADD_IMAGE":
@@ -74,9 +44,12 @@ function updateFormDataReducer(
     case "UPDATE_SEARCH_TAGS":
       newState = updateSearchTags(state, action.payload);
       break;
+    case "REMOVE_IMAGE":
+      newState = removeImage(state, action.payload);
+      break;
 
     default:
-      console.log("no action available for ", LOC, action.type);
+      console.log("no action available for ", LOC, action);
       return state;
       break;
   }
@@ -152,9 +125,8 @@ function updateInstruction(state: Repair, payload: ChangeFormPayloadT): Repair {
 }
 
 ///UPDATE IMAGE action
-//!working on here cant the newImage url is undefined** works but check again
 function updateImage(state: Repair, payload: ChangeFormPayloadT) {
-  const { procIndex, newImageIndex, newImageObj } = payload;
+  const { procIndex, imageIndex: newImageIndex, newImageObj } = payload;
 
   //does image exists, have an index to update at, and index is valid if not then do nothing
   if (
@@ -201,6 +173,61 @@ function updateImage(state: Repair, payload: ChangeFormPayloadT) {
 
   return state as Repair;
   // return { ...state, procedureArr: newProcedures } as RepairFormT;
+}
+
+//remove image from both images and imageObj arrays
+function removeImage(state: Repair, payload: ChangeFormPayloadT) {
+  const { procIndex, imageIndex, imageId } = payload;
+
+  //does image exist, have an index to remove at, and index is valid if not then do nothing
+  if (typeof imageIndex != "number") {
+    console.log("payload", payload);
+    console.log(
+      "no index to update or url to update with image @useUpdateProcedures.updateImage"
+    );
+
+    return state;
+  }
+
+  if (typeof procIndex != "number") {
+    return state;
+  }
+
+  //get images if any from procedure
+  const images = state.procedureArr[procIndex]?.images;
+  const imageObjs = state.procedureArr[procIndex]?.imageObjs;
+
+  // const procIndex = payload.procIndex;
+  const targetProc = state.procedureArr[procIndex];
+  const imageIndexToRemove = imageIndex;
+
+  //update legacy image urls property
+
+  //todo combine into one loop
+
+  const newImages: string[] = [];
+  images.forEach((item, index) => {
+    if (index == imageIndexToRemove) {
+      return;
+    }
+    newImages.push(item);
+  });
+
+  targetProc.images = newImages;
+
+  const newImageObjs: ImageObjT[] = [];
+  imageObjs.forEach((item, index) => {
+    if (index == imageIndexToRemove) {
+      return;
+    }
+
+    newImageObjs.push(item);
+  });
+
+  targetProc.imageObjs = newImageObjs;
+
+  console.log("state", state.procedureArr);
+  return { ...state } as Repair;
 }
 
 function addEmptyImageToProcedure(state: Repair, payload: ChangeFormPayloadT) {

--- a/client/src/hooks/useRepairFormState.ts
+++ b/client/src/hooks/useRepairFormState.ts
@@ -179,11 +179,15 @@ function updateImage(state: Repair, payload: ChangeFormPayloadT) {
 function removeImage(state: Repair, payload: ChangeFormPayloadT) {
   const { procIndex, imageIndex, imageId } = payload;
 
+  //todo trying to filter based on imageId which is generated in cosntructor and will
+  //todo replaced when image is uploaded with unique id
+  const targetId = imageId;
+
   //does image exist, have an index to remove at, and index is valid if not then do nothing
-  if (typeof imageIndex != "number") {
+  if (!imageId) {
     console.log("payload", payload);
     console.log(
-      "no index to update or url to update with image @useUpdateProcedures.updateImage"
+      "no index to update or url to update with image @useUpdateProcedures.removeImage"
     );
 
     return state;
@@ -193,36 +197,19 @@ function removeImage(state: Repair, payload: ChangeFormPayloadT) {
     return state;
   }
 
-  //get images if any from procedure
-  const images = state.procedureArr[procIndex]?.images;
-  const imageObjs = state.procedureArr[procIndex]?.imageObjs;
-
-  // const procIndex = payload.procIndex;
   const targetProc = state.procedureArr[procIndex];
-  const imageIndexToRemove = imageIndex;
 
-  //update legacy image urls property
+  //get images if any from procedure
+  // const images = state.procedureArr[procIndex]?.images;
+  const imageObjs = targetProc?.imageObjs;
+  const newImageObjs = imageObjs.filter((item, index) => {
+    console.log("item", item);
 
-  //todo combine into one loop
+    if (item.imageId == targetId) return false;
 
-  const newImages: string[] = [];
-  images.forEach((item, index) => {
-    if (index == imageIndexToRemove) {
-      return;
-    }
-    newImages.push(item);
+    return true;
   });
-
-  targetProc.images = newImages;
-
-  const newImageObjs: ImageObjT[] = [];
-  imageObjs.forEach((item, index) => {
-    if (index == imageIndexToRemove) {
-      return;
-    }
-
-    newImageObjs.push(item);
-  });
+  // const procIndex = payload.procIndex;
 
   targetProc.imageObjs = newImageObjs;
 

--- a/client/src/hooks/useRepairFormState.ts
+++ b/client/src/hooks/useRepairFormState.ts
@@ -1,9 +1,5 @@
 import { useReducer } from "react";
-import {
-  ChangeFormPayloadT,
-  ImageObjT,
-  RepairFormStateActionT,
-} from "../../types";
+import { ChangeFormPayloadT, RepairFormStateActionT } from "../../types";
 import { Repair } from "../classes/Repair";
 import { ImageObj } from "../classes/ImageObj";
 import { Procedure } from "../classes/Procedure";
@@ -177,7 +173,7 @@ function updateImage(state: Repair, payload: ChangeFormPayloadT) {
 
 //remove image from both images and imageObj arrays
 function removeImage(state: Repair, payload: ChangeFormPayloadT) {
-  const { procIndex, imageIndex, imageId } = payload;
+  const { procIndex, imageId } = payload;
 
   //todo trying to filter based on imageId which is generated in cosntructor and will
   //todo replaced when image is uploaded with unique id
@@ -202,7 +198,7 @@ function removeImage(state: Repair, payload: ChangeFormPayloadT) {
   //get images if any from procedure
   // const images = state.procedureArr[procIndex]?.images;
   const imageObjs = targetProc?.imageObjs;
-  const newImageObjs = imageObjs.filter((item, index) => {
+  const newImageObjs = imageObjs.filter((item) => {
     console.log("item", item);
 
     if (item.imageId == targetId) return false;

--- a/client/types.ts
+++ b/client/types.ts
@@ -102,6 +102,14 @@ export type repairDataT = {
   _id: string;
 };
 
+export type signatureT = {
+  apikey: string;
+  cloudname: string;
+  signature: string;
+  timestamp: number;
+  folder: string;
+};
+
 // export type imageObjT = {
 //   imageUrl: string;
 //   imageThumb: string;
@@ -129,4 +137,5 @@ export type repairDataT = {
 //   title: string;
 //   visibility: string;
 //   _id: string;
+
 // };

--- a/client/types.ts
+++ b/client/types.ts
@@ -32,31 +32,33 @@ export type ChangeFormPayloadT = {
   procIndex?: number;
   instructions?: string;
   newImageUrl?: string;
-  newImageIndex?: number;
+  imageIndex?: number;
   newImageObj?: ImageObjT;
   allProcedures?: ProcedureT[];
   formField?: Record<string, string>;
   searchTags?: string[];
+  imageId?: string;
 };
 
-export type RepairFormDispatchType =
-  | "UPDATE_IMAGES"
-  | "ADD_IMAGE"
-  | "UPDATE_INTRUC"
-  | "ADD_PROCEDURE"
-  | "REMOVE_PROCEDURE"
-  | "UPDATE_PROCEDURES"
-  | "UPDATE_FIELD"
-  | "UPDATE_SEARCH_TAGS";
+// export type RepairFormDispatchType =
+//   | "ADD_IMAGE"
+//   | "ADD_PROCEDURE"
+//   | "REMOVE_PROCEDURE"
+//   | "REMOVE_IMAGE"
+//   | "UPDATE_IMAGES"
+//   | "UPDATE_INTRUC"
+//   | "UPDATE_PROCEDURES"
+//   | "UPDATE_FIELD"
+//   | "UPDATE_SEARCH_TAGS";
 
-export type RepairFormDispatchT = React.Dispatch<RepairFormStateDispatchT>;
+export type RepairFormDispatchT = React.Dispatch<RepairFormStateActionT>;
 
 // export type RepairFormDispatchT = React.Dispatch<{
 //   type: RepairFormDispatchType;
 //   payload: ChangeFormPayloadT;
 // }>;
 
-export type RepairFormStateDispatchT =
+export type RepairFormStateActionT =
   | {
       type: "UPDATE_SEARCH_TAGS";
       payload: { searchTags: string[] };
@@ -81,8 +83,15 @@ export type RepairFormStateDispatchT =
       type: "UPDATE_IMAGES";
       payload: {
         procIndex: number;
-        newImageIndex: number;
+        imageIndex: number;
         newImageObj: ImageObjT;
+      };
+    }
+  | {
+      type: "REMOVE_IMAGE";
+      payload: {
+        procIndex: number;
+        imageId: string;
       };
     }
   | {


### PR DESCRIPTION
images can be removed from new repair form and a call to backend api is made to delete image form database

- ImageId is sent to back end to target specific image
- imageObj class now has a uuid() in the imageId field as default to be able to target when removing from form and image has not been uploaded yet
- when image is uploaded manual upload button is removed
- added /api/image endpoint to backend
- added useImageManager to handle image api interaction