### PR TITLE
fix when adding new procedure next to last will add to end

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=""

--- a/client/src/components/ProcedureList/EditProcedureList.tsx
+++ b/client/src/components/ProcedureList/EditProcedureList.tsx
@@ -11,10 +11,6 @@ export default function EditProcedureList({
   procedureList: ProcedureT[];
   formDispatch: RepairFormDispatchT;
 }): React.ReactNode {
-  //
-
-  // const { currentFormState: procedureList, formDispatch } = useRepairFormState();
-
   const addNewProcedure = (index: number) => {
     formDispatch({
       type: "ADD_PROCEDURE",
@@ -23,45 +19,11 @@ export default function EditProcedureList({
   };
 
   const procedures = procedureList.map((procedureData, procedureIndex) => {
-    const instructions = (text: string) => {
-      formDispatch({
-        type: "UPDATE_INTRUC",
-        payload: { procIndex: procedureIndex, instructions: text },
-      });
-    };
-    const addImage = () => {
-      formDispatch({
-        type: "ADD_IMAGE",
-        payload: { procIndex: procedureIndex },
-      });
-    };
-
-    const editImage = (imageIndex: number, updatedImageObj: ImageObjT) => {
-      formDispatch({
-        type: "UPDATE_IMAGES",
-        payload: {
-          procIndex: procedureIndex,
-          imageIndex: imageIndex,
-          newImageObj: updatedImageObj,
-        },
-      });
-    };
-
-    //! working on this
-    const removeImage = (imageId: string) => {
-      formDispatch({
-        type: "REMOVE_IMAGE",
-        payload: { imageId, procIndex: procedureIndex },
-      });
-    };
-
     //object with update functions for editProcedureCard component
-    const updateProcedureMethods = {
-      instructions,
-      addImage,
-      editImage,
-      removeImage,
-    };
+    const updateProcedureMethods = generateProcedureMethods({
+      formDispatch,
+      procedureIndex,
+    });
 
     return (
       <li key={uuidv4()}>
@@ -94,4 +56,51 @@ export default function EditProcedureList({
       <ul className="w-full">{procedures}</ul>
     </div>
   );
+}
+
+//create methods for specific procedure based on there index position
+function generateProcedureMethods({
+  procedureIndex,
+  formDispatch,
+}: {
+  procedureIndex: number;
+  formDispatch: RepairFormDispatchT;
+}) {
+  const instructions = (text: string) => {
+    formDispatch({
+      type: "UPDATE_INTRUC",
+      payload: { procIndex: procedureIndex, instructions: text },
+    });
+  };
+
+  const addImage = () => {
+    formDispatch({
+      type: "ADD_IMAGE",
+      payload: { procIndex: procedureIndex },
+    });
+  };
+
+  const editImage = (imageIndex: number, updatedImageObj: ImageObjT) => {
+    formDispatch({
+      type: "UPDATE_IMAGES",
+      payload: {
+        procIndex: procedureIndex,
+        imageIndex: imageIndex,
+        newImageObj: updatedImageObj,
+      },
+    });
+  };
+
+  const removeImage = (imageId: string) => {
+    formDispatch({
+      type: "REMOVE_IMAGE",
+      payload: { imageId, procIndex: procedureIndex },
+    });
+  };
+  return {
+    instructions,
+    addImage,
+    editImage,
+    removeImage,
+  };
 }

--- a/client/src/hooks/useRepairFormState.ts
+++ b/client/src/hooks/useRepairFormState.ts
@@ -81,7 +81,8 @@ function addProcedure(state: Repair, payload: ChangeFormPayloadT) {
     };
   }
 
-  if (procIndex >= oldProcedures.length - 1) {
+  //if new index is larger than old array add new instance to end of state
+  if (procIndex > oldProcedures.length - 1) {
     return { ...state, procedureArr: [...oldProcedures, new Procedure()] };
   }
 


### PR DESCRIPTION
- fix adding new procedure before last in list was adding to end instead of where intended
- small refactor to EditProcedureList to move generating procedure edit methods to its own function and out of the map function
- updated .env.example