### PR TITLE
307 display users groups memberships

### DIFF
--- a/client/src/components/Invite/InviteToolContainer.tsx
+++ b/client/src/components/Invite/InviteToolContainer.tsx
@@ -2,14 +2,17 @@ import { useEffect } from "react";
 import useInviteManager from "../../hooks/useInviteManager";
 import InviteLog from "./InviteLog";
 import InviteTool from "./InviteTool";
-import useGetUserGroups from "../../hooks/useGetUserGroups";
+import useGetUserGroups, { UserGroupDataT } from "../../hooks/useGetUserGroups";
 import isInviteAllowed from "../../hooks/utils/isInviteAllowed";
 
-export default function InviteToolContainer() {
+export default function InviteToolContainer({
+  userGroupMemberships = [],
+}: {
+  userGroupMemberships: UserGroupDataT[];
+}) {
   //todo get any invites user has pending
   const { getUserInvites, data: inviteData, postInvite } = useInviteManager();
-  const { data: userGroupMemberships, fetchData: getUserGroupData } =
-    useGetUserGroups();
+  const { fetchData: getUserGroupData } = useGetUserGroups();
 
   const inviteAllowedGroups = userGroupMemberships.filter((groupData) => {
     return isInviteAllowed(groupData);

--- a/client/src/components/Profile/UserStats/UserStats.tsx
+++ b/client/src/components/Profile/UserStats/UserStats.tsx
@@ -1,6 +1,6 @@
 type UserStatsPropsT = {
-  totalRepairs: number;
-  groupsList: GroupListingT[];
+  totalRepairs?: number;
+  groupsList?: GroupListingT[];
 };
 
 export type GroupListingT = {

--- a/client/src/components/Profile/UserStats/UserStats.tsx
+++ b/client/src/components/Profile/UserStats/UserStats.tsx
@@ -1,4 +1,20 @@
-export default function UserStats() {
+type UserStatsPropsT = {
+  totalRepairs: number;
+  groupsList: GroupListingT[];
+};
+
+export type GroupListingT = {
+  groupName: string;
+  role: string[];
+  groupId: string;
+};
+
+export default function UserStats({
+  totalRepairs = 0,
+  groupsList = [],
+}: UserStatsPropsT) {
+  const rows = createRows(groupsList);
+
   return (
     <div className="flex flex-col">
       <div className="self-center">
@@ -8,22 +24,55 @@ export default function UserStats() {
           </div>
         </div>
       </div>
-      <div className="flex justify-center">
-        <section className="flex gap-1">
-          <button className="btn ">
+      <div className="flex justify-center items-center">
+        {/* <section className="flex gap-1"> */}
+        <section>
+          <div className="btn ">
             <div>
               <span className="block">Total Repairs</span>
-              <div className="badge">99</div>
+              <div className="badge">{totalRepairs}</div>
             </div>
-          </button>
-          <button className="btn ">
-            <div>
-              <span className="block">Joined Groups</span>
-              <div className="badge">99</div>
-            </div>
-          </button>
+          </div>
         </section>
+
+        <section className="flex gap-1 items-center">
+          <details className="dropdown">
+            <summary className="btn m-1 flex flex-col">
+              <span className="block">Joined Groups</span>
+              <span className="badge">{groupsList.length}</span>
+            </summary>
+            <ul className="menu dropdown-content bg-base-100 rounded-box z-[1] w-52 p-2 shadow ">
+              <li>
+                <div className="h-96 overflow-x-auto">
+                  <table className="table table-pin-rows">
+                    <thead>
+                      <tr>
+                        <th>Group</th>
+                        <th>Role</th>
+                      </tr>
+                    </thead>
+                    <tbody>{rows}</tbody>
+                  </table>
+                </div>
+              </li>
+            </ul>
+          </details>
+        </section>
+        {/* </section> */}
       </div>
     </div>
   );
+}
+
+function createRows(groupList: GroupListingT[]) {
+  if (!groupList.length) return [];
+
+  return groupList.map((listing) => {
+    return (
+      <tr data-testid="group-listing">
+        <td>{listing.groupName}</td>
+        <td>{listing.role}</td>
+      </tr>
+    );
+  });
 }

--- a/client/src/components/Profile/UserStats/UserStatsContainer.tsx
+++ b/client/src/components/Profile/UserStats/UserStatsContainer.tsx
@@ -1,7 +1,0 @@
-import UserStats from "./UserStats";
-
-export default function UserStatsContainer() {
-  //todo get users total repairs
-  //todo get total groups user belongs to
-  return <UserStats />;
-}

--- a/client/src/hooks/useGetUserGroups.ts
+++ b/client/src/hooks/useGetUserGroups.ts
@@ -10,7 +10,6 @@ export type UserGroupDataT = {
   username: string;
   role: string[];
   groupId: string;
-
   groupName: string;
 };
 
@@ -30,10 +29,6 @@ export default function useGetUserGroups() {
       setError(["failed to get groups memberships"]);
     }
   };
-
-  useEffect(() => {
-    getUserGroups();
-  }, []);
 
   return { data: groups, fetchData: getUserGroups, error };
 }

--- a/client/src/pages/Profile/ProfilePage.tsx
+++ b/client/src/pages/Profile/ProfilePage.tsx
@@ -1,8 +1,18 @@
+import { useEffect } from "react";
+import ErrorBoundary from "../../components/ErrorBoundary/ErrorBoundary";
 import InviteToolContainer from "../../components/Invite/InviteToolContainer";
 import UserInfoContainer from "../../components/Profile/UserInfoContainer";
 import UserStats from "../../components/Profile/UserStats/UserStats";
+import useGetUserGroups from "../../hooks/useGetUserGroups";
 
 export default function ProfilePage(): React.ReactNode {
+  const { data: userGroupMemberships, fetchData: getUserGroupData } =
+    useGetUserGroups();
+
+  useEffect(() => {
+    getUserGroupData();
+  }, []);
+
   return (
     <section className="text-slate-400   flex flex-col ">
       <div className="flex">
@@ -11,13 +21,19 @@ export default function ProfilePage(): React.ReactNode {
             <UserInfoContainer />
           </div>
           <div className="p-2">
-            <InviteToolContainer />
+            <ErrorBoundary componentName="InviteTool">
+              <InviteToolContainer
+                userGroupMemberships={userGroupMemberships}
+              />
+            </ErrorBoundary>
           </div>
         </main>
 
         {/* side bar */}
         <aside className="w-2/6 min-h-[400px] m-0 bg-green-900 p-1">
-          <UserStats />
+          <ErrorBoundary componentName="UserStats">
+            <UserStats groupsList={userGroupMemberships} />
+          </ErrorBoundary>
         </aside>
       </div>
     </section>

--- a/client/tests/components/Profile/UserStats/UserStats.test.tsx
+++ b/client/tests/components/Profile/UserStats/UserStats.test.tsx
@@ -1,0 +1,72 @@
+import UserStats, {
+  GroupListingT,
+} from "../../../../src/components/Profile/UserStats/UserStats";
+import {
+  getAllByRole,
+  getByText,
+  render,
+  screen,
+} from "@testing-library/react";
+import "@testing-library/jest-dom/vitest";
+import { it, expect, describe } from "vitest";
+import React from "react";
+
+const testGroupListProp: GroupListingT[] = [
+  {
+    groupId: "1111",
+    groupName: "number1",
+    role: ["read", "invite"],
+  },
+  {
+    groupId: "22222",
+    groupName: "number2",
+    role: ["read"],
+  },
+];
+
+const testTotalRepairsProp = 4;
+
+describe("UserStats", () => {
+  it("should display table with corect number of listings", () => {
+    render(
+      <UserStats
+        groupsList={testGroupListProp}
+        totalRepairs={testTotalRepairsProp}
+      />
+    );
+
+    const table = screen.getByRole("table");
+    const tableRows = getAllByRole(table, "row");
+
+    //plus on for the table header also counts as row
+
+    testGroupListProp.forEach((groupData) => {
+      screen.getByText(groupData.groupName);
+    });
+
+    expect(tableRows.length).toBe(testGroupListProp.length + 1);
+  });
+
+  it("should display total number of repairs", () => {
+    render(
+      <UserStats
+        groupsList={testGroupListProp}
+        totalRepairs={testTotalRepairsProp}
+      />
+    );
+    screen.getByText(testTotalRepairsProp);
+  });
+
+  it("should display correct roles", () => {
+    render(
+      <UserStats
+        groupsList={testGroupListProp}
+        totalRepairs={testTotalRepairsProp}
+      />
+    );
+
+    const targetCell = screen.getByText(/invite/i);
+    const targetRow = targetCell.closest("tr");
+    getByText(targetRow, testGroupListProp[0].groupName);
+  });
+});

--- a/client/tests/hooks/useGetUserGroups.test.ts
+++ b/client/tests/hooks/useGetUserGroups.test.ts
@@ -17,6 +17,8 @@ const mockReturn: UserGroupDataT[] = [
   },
 ];
 
+const callFetchDataTimes = 3;
+
 //@ts-expect-error mocking only data part of axios response
 const mockAxiosResponse: AxiosResponse<UserGroupDataT[], unknown> = {
   data: mockReturn,
@@ -33,14 +35,14 @@ describe("useGetUserGroups", () => {
     const { result } = renderHook(() => useGetUserGroups());
 
     await act(async () => {
-      await result.current.fetchData();
-      await result.current.fetchData();
+      for (let i = 0; i < callFetchDataTimes; i++)
+        await result.current.fetchData();
     });
 
     await waitFor(() => {
       expect(Array.isArray(result.current.data)).toBe(true);
       expect(result.current.data.length).toBe(mockReturn.length);
-      expect(axiosMockGet).toBeCalledTimes(3);
+      expect(axiosMockGet).toBeCalledTimes(callFetchDataTimes);
     });
 
     await vi.waitFor(


### PR DESCRIPTION
- add tests for UserStats
- refactor useGetUserGroups hook to remove useEffect to autofetch data
- refactor ProfilePage to use useGetUserGroups hook
- update useGetUserGroups tests
- removed unused redundant client/src/components/Profile/UserStats/UserStatsContainer.tsx Profile page is the container